### PR TITLE
bug fix for repeat invocations appending identify/track

### DIFF
--- a/lib/heap-server.js
+++ b/lib/heap-server.js
@@ -10,13 +10,13 @@
 
 var xtend = require('xtend');
 var request = require('request')
+var HEAP_URL = 'https://heapanalytics.com/api/';
 
 module.exports = Heap;
 
 function Heap(id, debug) {
   if (!(this instanceof Heap)) return new Heap(id);
   if (!id) throw new TypeError('An api token is required');
-  this.remote = 'https://heapanalytics.com/api/';
   this.config = {
     'app_id': id
   };
@@ -27,10 +27,10 @@ Heap.prototype.push = function(data, callback) {
   var result = xtend(this.config, data);
 
   if(result.event){
-    this.remote = this.remote + 'track';
+    this.remote = HEAP_URL + 'track';
   }
   else{
-    this.remote = this.remote + 'identify';
+    this.remote = HEAP_URL + 'identify';
   }
 
   var options = {


### PR DESCRIPTION
when calling heap.push repeatedly, the request URL appends 'identify' or 'track' repeatedly, so the second call has a request URL of https://heapanalytics.com/api/identifyidentify and so on.

This should fix it, but feel free to adjust according to your preferred style
